### PR TITLE
Add Power System

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/shurizzle/rust-smc"
 keywords = ["macos", "smc", "cpu", "fan", "themal"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-byteorder = "1.4"
 lazy_static = "1.4.0"
 libc = "0.2.145"
 four-char-code = "0.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/shurizzle/rust-smc"
 keywords = ["macos", "smc", "cpu", "fan", "themal"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-lazy_static = "1.3.0"
-libc = "0.2.50"
+lazy_static = "1.4.0"
+libc = "0.2.145"
 four-char-code = "0.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/shurizzle/rust-smc"
 keywords = ["macos", "smc", "cpu", "fan", "themal"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
+byteorder = "1.4"
 lazy_static = "1.4.0"
 libc = "0.2.145"
 four-char-code = "0.0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,10 +596,6 @@ impl SMC {
         self.0.read_key(key)
     }
 
-    pub fn write_key<T: SMCType>(&self, key: FourCharCode, value: T) -> Result<(), SMCError> {
-        self.0.write_key(key, value)
-    }
-
     fn _keys_len(&self) -> Result<u32, SMCError> {
         self.0.read_key(four_char_code!("#KEY"))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,6 @@ extern crate lazy_static;
 mod conversions;
 mod sys;
 
-use byteorder::ReadBytesExt;
-use std::io::Cursor;
-
 use std::collections::HashMap;
 use std::fmt;
 use std::os::raw::c_void;
@@ -417,9 +414,7 @@ impl Power {
     pub fn is_charging_enabled(&self) -> Result<bool, SMCError> {
         // This one has an odd type code "hex_"
         let charging_enabled = self.smc_repr.read_key_raw(FourCharCode::from("CH0B"))?;
-        let mut cursor = Cursor::new(charging_enabled.0);
-        let charging_enabled: u8 = cursor.read_u8().unwrap();
-        Ok(charging_enabled == 0)
+        Ok(charging_enabled.0[0] == 0)
     }
     /// Enables charging.
     pub fn enable_charging(&self) -> Result<(), SMCError> {
@@ -452,7 +447,7 @@ impl Power {
     /// Checks if the laptop is plugged in.
     pub fn is_plugged_in(&self) -> Result<bool, SMCError> {
         let ac_present: i8 = self.smc_repr.read_key(FourCharCode::from("AC-W"))?;
-        Ok(ac_present == 1)
+        Ok(ac_present == 4)
     }
 }
 


### PR DESCRIPTION
Added some code to support interacting with the power system on M1 mac's. I also added a `read_key_raw` because the return type from `is_charging_enabled` doesn't seem to match any of the existing types defined. It looks like it decodes to `hex_` but that doesn't make a much sense. 